### PR TITLE
Fix appspec and scripts

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -2,19 +2,24 @@ version: 0.0
 os: linux
 files:
   - source: /
-    destination: /var/www/html/sinatra
+    destination: /home/ec2-user/sinatra
+permissions:
+  - object: /home/ec2-user/sinatra
+    owner: ec2-user
+    group: ec2-user
+    mode: 644
 hooks:
   BeforeInstall:
     - location: scripts/install_dependencies.sh
-      timeout: 300
+      timeout: 600
       runas: root
     - location: scripts/install_gems.sh
-      timeout: 300
+      timeout: 600
       runas: ec2-user
   ApplicationStart:
     - location: scripts/start_server.sh
       timeout: 300
-      runas: root
+      runas: ec2-user
   ApplicationStop:
     - location: scripts/stop_server.sh
       timeout: 300

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -6,6 +6,8 @@ yum install -y ruby-rdoc ruby-devel
 yum install -y rubygems
 yum install -y git
 
+
+# Shutdown if httpd launched
 httpd=`pgrep httpd`
 
 if [[ -n "$httpd" ]]; then

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -4,6 +4,10 @@ yum install -y ruby
 yum install -y gcc g++ make automake autoconf curl-devel openssl-devel zlib-devel httpd-devel apr-devel apr-util-devel sqlite-devel
 yum install -y ruby-rdoc ruby-devel
 yum install -y rubygems
+yum install -y git
 
-gem install bundler
-bundle
+httpd=`pgrep httpd`
+
+if [[ -n "$httpd" ]]; then
+  service httpd stop
+fi

--- a/scripts/install_gems.sh
+++ b/scripts/install_gems.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
 gem install bundler
+gem install sinatra
+gem install rack
+gem install io-console
+
+bundle install --path=/home/ec2-user/sinatra
+echo `whoami`

--- a/scripts/install_gems.sh
+++ b/scripts/install_gems.sh
@@ -4,6 +4,3 @@ gem install bundler
 gem install sinatra
 gem install rack
 gem install io-console
-
-bundle install --path=/home/ec2-user/sinatra
-echo `whoami`

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
 
-rackup -p 80 -o 0.0.0.0 -P rack.pid
+echo `whoami`
+echo `pwd`
+
+export PATH="/usr/local/bin:$PATH"
+cd /home/ec2-user/sinatra
+
+echo "BUNDLE_GEMFILE : $BUNDLE_GEMFILE"
+echo `pwd`
+
+unset BUNDLE_GEMFILE
+
+gem install bundler
+echo `which bundle`
+
+~/bin/bundle install
+~/bin/rackup -p 8080 -o 0.0.0.0 -D

--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -1,18 +1,8 @@
 #!/bin/bash
 
-echo `whoami`
-echo `pwd`
-
-export PATH="/usr/local/bin:$PATH"
 cd /home/ec2-user/sinatra
 
-echo "BUNDLE_GEMFILE : $BUNDLE_GEMFILE"
-echo `pwd`
-
-unset BUNDLE_GEMFILE
-
 gem install bundler
-echo `which bundle`
 
-~/bin/bundle install
-~/bin/rackup -p 8080 -o 0.0.0.0 -D
+/home/ec2-user/bin/bundle install
+/home/ec2-user/bin/rackup -p 8080 -o 0.0.0.0 -D

--- a/scripts/stop_server.sh
+++ b/scripts/stop_server.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-cd ..
-kill `cat rack.pid`
+rm -rf /home/ec2-user/sinatra
+
+isExistApp=`pgrep rack`
+
+if [[ -n "$isExistApp" ]]; then
+   kill $isExistApp
+fi


### PR DESCRIPTION
`appspec.yml`:
- 低予算インスタンスではインストール フェーズでタイムアウトするので それを長めに設定
- パーミッション関係で躓くのにつかれたので ec2-user ホームディレクトリにデプロイ、とりあえずパーミッションの設定もしておく
- root で実行する理由がナサソウなのはec2-user で実行する

`install_dependencies.sh`:
- Ruby が欲しそうなパッケージを適当にインストール
- bundler gem のインストール記述場所が微妙だし重複してたから`install_gems.sh` に集約
- httpd つかわないので止める。(←記述場所がおかしい)

`install_gems.sh`:
- io-console gem がないとrackup のタイミングでエラーが出るのでインストール
- なんか不安なのでつかうgem を前もって入れておく。<<<なんか不安なので>>> !!!

`start_server.sh`: 
- `/home/ec2-user/bin` にgem 実行ファイルが置かれるようなので それを参照するよう記述
- rackup でpid ファイルを作るのにパーミッションエラーで作成できない&起動しないので、単純にdaemonize 
